### PR TITLE
Use self.ssl_verify when refresh the token for Gitee API

### DIFF
--- a/perceval/backends/gitee/gitee.py
+++ b/perceval/backends/gitee/gitee.py
@@ -738,7 +738,7 @@ class GiteeClient(HttpClient, RateLimitHandler):
         if self.access_token:
             url = GITEE_REFRESH_TOKEN_URL + "?grant_type=refresh_token&refresh_token=" + self.access_token
             logger.info("Refresh the access_token for Gitee API")
-            self.session.post(url, data=None, headers=None, stream=False, auth=None)
+            self.session.post(url, data=None, headers=None, stream=False, verify=self.ssl_verify, auth=None)
 
 
 class GiteeCommand(BackendCommand):


### PR DESCRIPTION
Sometimes we set `no-ssl-verify = true` in config file so in `_refresh_access_token` method, we should use the config.

Signed-off-by: Fugang Xiao <xiao623@outlook.com>